### PR TITLE
refactor: convert slices from CRTP to C++20 concepts

### DIFF
--- a/include/xtensor/views/xdynamic_view.hpp
+++ b/include/xtensor/views/xdynamic_view.hpp
@@ -324,7 +324,7 @@ namespace xt
     namespace detail
     {
         template <class T>
-        class xfake_slice : public xslice<xfake_slice<T>>
+        class xfake_slice
         {
         public:
 

--- a/include/xtensor/views/xslice.hpp
+++ b/include/xtensor/views/xslice.hpp
@@ -761,9 +761,13 @@ namespace xt
             type operator()(T t)
             {
                 if constexpr (xtl::integral_concept<T>)
+                {
                     return static_cast<std::ptrdiff_t>(t);
+                }
                 else
+                {
                     return t;
+                }
             }
         };
 

--- a/include/xtensor/views/xslice.hpp
+++ b/include/xtensor/views/xslice.hpp
@@ -20,6 +20,7 @@
 
 #include "../containers/xstorage.hpp"
 #include "../core/xtensor_config.hpp"
+#include "../misc/xtl_concepts.hpp"
 #include "../utils/xutils.hpp"
 
 #ifndef XTENSOR_CONSTEXPR
@@ -426,7 +427,7 @@ namespace xt
     template <class R = std::ptrdiff_t, class T>
     inline auto keep(T&& indices)
     {
-        if constexpr (xtl::is_integral<std::decay_t<T>>::value)
+        if constexpr (xtl::integral_concept<std::decay_t<T>>)
         {
             using slice_type = xkeep_slice<R>;
             using container_type = typename slice_type::container_type;
@@ -535,7 +536,7 @@ namespace xt
     template <class R = std::ptrdiff_t, class T>
     inline auto drop(T&& indices)
     {
-        if constexpr (xtl::is_integral<T>::value)
+        if constexpr (xtl::integral_concept<T>)
         {
             using slice_type = xdrop_slice<R>;
             using container_type = typename slice_type::container_type;
@@ -574,11 +575,11 @@ namespace xt
         template <class MI = A, class MA = B, class STEP = C>
         auto get(std::size_t size) const
         {
-            if constexpr (xtl::is_integral<MI>::value && xtl::is_integral<MA>::value && xtl::is_integral<STEP>::value)
+            if constexpr (xtl::integral_concept<MI> && xtl::integral_concept<MA> && xtl::integral_concept<STEP>)
             {
                 return get_stepped_range(m_start, m_stop, m_step, size);
             }
-            else if constexpr (!xtl::is_integral<MI>::value && xtl::is_integral<MA>::value && xtl::is_integral<STEP>::value)
+            else if constexpr (!xtl::integral_concept<MI> && xtl::integral_concept<MA> && xtl::integral_concept<STEP>)
             {
                 return get_stepped_range(
                     m_step > 0 ? 0 : static_cast<std::ptrdiff_t>(size) - 1,
@@ -587,30 +588,30 @@ namespace xt
                     size
                 );
             }
-            else if constexpr (xtl::is_integral<MI>::value && !xtl::is_integral<MA>::value && xtl::is_integral<STEP>::value)
+            else if constexpr (xtl::integral_concept<MI> && !xtl::integral_concept<MA> && xtl::integral_concept<STEP>)
             {
                 auto sz = static_cast<std::ptrdiff_t>(size);
                 return get_stepped_range(m_start, m_step > 0 ? sz : -(sz + 1), m_step, size);
             }
-            else if constexpr (xtl::is_integral<MI>::value && xtl::is_integral<MA>::value && !xtl::is_integral<STEP>::value)
+            else if constexpr (xtl::integral_concept<MI> && xtl::integral_concept<MA> && !xtl::integral_concept<STEP>)
             {
                 return xrange<std::ptrdiff_t>(normalize(m_start, size), normalize(m_stop, size));
             }
-            else if constexpr (!xtl::is_integral<MI>::value && !xtl::is_integral<MA>::value && xtl::is_integral<STEP>::value)
+            else if constexpr (!xtl::integral_concept<MI> && !xtl::integral_concept<MA> && xtl::integral_concept<STEP>)
             {
                 std::ptrdiff_t start = m_step >= 0 ? 0 : static_cast<std::ptrdiff_t>(size) - 1;
                 std::ptrdiff_t stop = m_step >= 0 ? static_cast<std::ptrdiff_t>(size) : -1;
                 return xstepped_range<std::ptrdiff_t>(start, stop, m_step);
             }
-            else if constexpr (xtl::is_integral<MI>::value && !xtl::is_integral<MA>::value && !xtl::is_integral<STEP>::value)
+            else if constexpr (xtl::integral_concept<MI> && !xtl::integral_concept<MA> && !xtl::integral_concept<STEP>)
             {
                 return xrange<std::ptrdiff_t>(normalize(m_start, size), static_cast<std::ptrdiff_t>(size));
             }
-            else if constexpr (!xtl::is_integral<MI>::value && xtl::is_integral<MA>::value && !xtl::is_integral<STEP>::value)
+            else if constexpr (!xtl::integral_concept<MI> && xtl::integral_concept<MA> && !xtl::integral_concept<STEP>)
             {
                 return xrange<std::ptrdiff_t>(0, normalize(m_stop, size));
             }
-            else if constexpr (!xtl::is_integral<MI>::value && !xtl::is_integral<MA>::value && !xtl::is_integral<STEP>::value)
+            else if constexpr (!xtl::integral_concept<MI> && !xtl::integral_concept<MA> && !xtl::integral_concept<STEP>)
             {
                 return xall<std::ptrdiff_t>(static_cast<std::ptrdiff_t>(size));
             }
@@ -755,11 +756,14 @@ namespace xt
         template <class T>
         struct cast_if_integer
         {
-            using type = std::conditional_t<xtl::is_integral<T>::value, std::ptrdiff_t, T>;
+            using type = std::conditional_t<xtl::integral_concept<T>, std::ptrdiff_t, T>;
 
             type operator()(T t)
             {
-                return (xtl::is_integral<T>::value) ? static_cast<type>(t) : t;
+                if constexpr (xtl::integral_concept<T>)
+                    return static_cast<std::ptrdiff_t>(t);
+                else
+                    return t;
             }
         };
 

--- a/include/xtensor/views/xslice.hpp
+++ b/include/xtensor/views/xslice.hpp
@@ -122,7 +122,9 @@ namespace xt
     concept strided_compatible_concept = slice_or_scalar_concept<S> && !nonstrided_slice_concept<S>;
 
     template <class... E>
-    using has_xslice = std::disjunction<is_xslice<E>...>;
+    struct has_xslice : std::bool_constant<(xslice_concept<E> || ...)>
+    {
+    };
 
     /**************
      * slice tags *
@@ -821,7 +823,10 @@ namespace xt
         {
             return slice.size();
         }
-        return 1;
+        else
+        {
+            return 1;
+        }
     }
 
     /*******************************************************
@@ -835,7 +840,10 @@ namespace xt
         {
             return slice.step_size(idx);
         }
-        return 0;
+        else
+        {
+            return 0;
+        }
     }
 
     template <class S>
@@ -845,7 +853,10 @@ namespace xt
         {
             return slice.step_size(idx, n);
         }
-        return 0;
+        else
+        {
+            return 0;
+        }
     }
 
     /*********************************************

--- a/include/xtensor/views/xslice.hpp
+++ b/include/xtensor/views/xslice.hpp
@@ -73,13 +73,12 @@ namespace xt
 
         template <class S>
         struct is_xslice_impl : std::disjunction<
-            is_specific_slice_impl<S, xrange>,
-            is_specific_slice_impl<S, xstepped_range>,
-            is_specific_slice_impl<S, xall>,
-            is_specific_slice_impl<S, xnewaxis>,
-            is_specific_slice_impl<S, xkeep_slice>,
-            is_specific_slice_impl<S, xdrop_slice>
-        >
+                                    is_specific_slice_impl<S, xrange>,
+                                    is_specific_slice_impl<S, xstepped_range>,
+                                    is_specific_slice_impl<S, xall>,
+                                    is_specific_slice_impl<S, xnewaxis>,
+                                    is_specific_slice_impl<S, xkeep_slice>,
+                                    is_specific_slice_impl<S, xdrop_slice>>
         {
         };
     }

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -713,11 +713,11 @@ namespace xt
         template <typename std::decay_t<CT>::size_type I, class... Args>
         size_type index(Args... args) const;
 
-        template <typename std::decay_t<CT>::size_type, class T>
-        size_type sliced_access(const xslice<T>& slice) const;
+        template <typename std::decay_t<CT>::size_type I, xslice_concept T>
+        size_type sliced_access(const T& slice) const;
 
-        template <typename std::decay_t<CT>::size_type I, class T, class Arg, class... Args>
-        size_type sliced_access(const xslice<T>& slice, Arg arg, Args... args) const;
+        template <typename std::decay_t<CT>::size_type I, xslice_concept T, class Arg, class... Args>
+        size_type sliced_access(const T& slice, Arg arg, Args... args) const;
 
         template <typename std::decay_t<CT>::size_type I, class T, class... Args>
         size_type sliced_access(const T& squeeze, Args...) const
@@ -1657,20 +1657,18 @@ namespace xt
     }
 
     template <class CT, class... S>
-    template <typename std::decay_t<CT>::size_type I, class T>
-    inline auto xview<CT, S...>::sliced_access(const xslice<T>& slice) const -> size_type
+    template <typename std::decay_t<CT>::size_type I, xslice_concept T>
+    inline auto xview<CT, S...>::sliced_access(const T& slice) const -> size_type
     {
-        return static_cast<size_type>(slice.derived_cast()(0));
+        return static_cast<size_type>(slice(0));
     }
 
     template <class CT, class... S>
-    template <typename std::decay_t<CT>::size_type I, class T, class Arg, class... Args>
-    inline auto xview<CT, S...>::sliced_access(const xslice<T>& slice, Arg arg, Args... args) const -> size_type
+    template <typename std::decay_t<CT>::size_type I, xslice_concept T, class Arg, class... Args>
+    inline auto xview<CT, S...>::sliced_access(const T& slice, Arg arg, Args... args) const -> size_type
     {
         using ST = typename T::size_type;
-        return static_cast<size_type>(
-            slice.derived_cast()(argument<I>(static_cast<ST>(arg), static_cast<ST>(args)...))
-        );
+        return static_cast<size_type>(slice(argument<I>(static_cast<ST>(arg), static_cast<ST>(args)...)));
     }
 
     template <class CT, class... S>

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -135,27 +135,12 @@ namespace xt
                                               : false;
         };
 
-        template <class S>
-        struct is_strided_slice_impl : std::true_type
-        {
-        };
-
-        template <class T>
-        struct is_strided_slice_impl<xkeep_slice<T>> : std::false_type
-        {
-        };
-
-        template <class T>
-        struct is_strided_slice_impl<xdrop_slice<T>> : std::false_type
-        {
-        };
-
         // If we have no discontiguous slices, we can calculate strides for this view.
         template <class E, class... S>
         struct is_strided_view
             : std::integral_constant<
                   bool,
-                  std::conjunction<has_data_interface<E>, is_strided_slice_impl<std::decay_t<S>>...>::value>
+                  has_data_interface<E>::value && (strided_compatible_concept<std::decay_t<S>> && ...)>
         {
         };
 

--- a/include/xtensor/views/xview.hpp
+++ b/include/xtensor/views/xview.hpp
@@ -706,7 +706,7 @@ namespace xt
 
         template <typename std::decay_t<CT>::size_type I, class T, class... Args>
         size_type sliced_access(const T& squeeze, Args...) const
-            requires(!is_xslice<T>::value);
+            requires(!xslice_concept<T>);
 
         using base_index_type = xindex_type_t<typename xexpression_type::shape_type>;
 
@@ -1659,7 +1659,7 @@ namespace xt
     template <class CT, class... S>
     template <typename std::decay_t<CT>::size_type I, class T, class... Args>
     inline auto xview<CT, S...>::sliced_access(const T& squeeze, Args...) const -> size_type
-        requires(!is_xslice<T>::value)
+        requires(!xslice_concept<T>)
     {
         return static_cast<size_type>(squeeze);
     }

--- a/include/xtensor/views/xview_utils.hpp
+++ b/include/xtensor/views/xview_utils.hpp
@@ -50,7 +50,7 @@ namespace xt
     template <class S, class It>
     inline auto get_slice_value(const S& slice, It& it) noexcept
     {
-        if constexpr (is_xslice<S>::value)
+        if constexpr (xslice_concept<S>)
         {
             return slice(typename S::size_type(*it));
         }


### PR DESCRIPTION
Replace xslice<D> CRTP base class with xslice_concept following xtensor's type-trait-first pattern. 


# Checklist

- [x] The title and commit message(s) are descriptive.
- [x] Small commits made to fix your PR have been squashed to avoid history pollution.
- [x] Tests have been added for new features or bug fixes.
- [x] API of new functions and classes are documented.

# Description

<!---
Give any relevant description here.
If your PR fixes an issue, please include "Fixes #ISSUE" (substituting the relevant issue ID).
-->
